### PR TITLE
[FEAT] 상품 조회 api 구현

### DIFF
--- a/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
@@ -1,0 +1,34 @@
+package com.solux.piccountbe.domain.item.controller;
+
+import com.solux.piccountbe.config.security.UserDetailsImpl;
+import com.solux.piccountbe.domain.item.dto.ItemResponseDto;
+import com.solux.piccountbe.domain.item.service.ItemService;
+import com.solux.piccountbe.global.Response;
+import com.solux.piccountbe.global.exception.CustomException;
+import com.solux.piccountbe.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/items")
+public class ItemController {
+    private final ItemService itemService;
+
+    @GetMapping("/calendar-skins")
+    public ResponseEntity<Response<List<ItemResponseDto>>> getCalendarSkins(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        List<ItemResponseDto> calendarSkins = itemService.getCalendarSkins();
+        return ResponseEntity.ok(Response.success("케이크 꾸미기 상품 목록 조회 성공", calendarSkins));
+    }
+}

--- a/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
@@ -21,6 +21,7 @@ import java.util.List;
 public class ItemController {
     private final ItemService itemService;
 
+    // 달력 꾸미기 상품 조회
     @GetMapping("/calendar-skins")
     public ResponseEntity<Response<List<ItemResponseDto>>> getCalendarSkins(
             @AuthenticationPrincipal UserDetailsImpl userDetails
@@ -29,6 +30,19 @@ public class ItemController {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
         List<ItemResponseDto> calendarSkins = itemService.getCalendarSkins();
-        return ResponseEntity.ok(Response.success("케이크 꾸미기 상품 목록 조회 성공", calendarSkins));
+        return ResponseEntity.ok(Response.success("달력 꾸미기 상품 목록 조회 성공", calendarSkins));
     }
+
+    // 케이크 꾸미기 상품 조회
+    @GetMapping("/cake-skins")
+    public ResponseEntity<Response<List<ItemResponseDto>>> getCakeSkins(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        List<ItemResponseDto> cakeSkins = itemService.getCakeSkins();
+        return ResponseEntity.ok(Response.success("케이크 꾸미기 상품 목록 조회 성공", cakeSkins));
+    }
+
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/controller/ItemController.java
@@ -45,4 +45,16 @@ public class ItemController {
         return ResponseEntity.ok(Response.success("케이크 꾸미기 상품 목록 조회 성공", cakeSkins));
     }
 
+    // 웹스킨 꾸미기 상품 조회
+    @GetMapping("/web-skins")
+    public ResponseEntity<Response<List<ItemResponseDto>>> getWebSkins(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        List<ItemResponseDto> webSkins = itemService.getWebSkins();
+        return ResponseEntity.ok(Response.success("웹 스킨 꾸미기 상품 목록 조회 성공", webSkins));
+    }
+
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/dto/ItemResponseDto.java
@@ -1,0 +1,15 @@
+package com.solux.piccountbe.domain.item.dto;
+
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ItemResponseDto {
+    private Long itemId;
+    private String name;
+    private ShopCategory category;
+    private Integer price;
+    private String imageUrl;
+}

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/Item.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/Item.java
@@ -24,8 +24,14 @@ public class Item {
 
 	@Column(nullable = false)
 	@Enumerated(value = EnumType.STRING)
-	private Category category;
+	private ShopCategory category;
 
 	@Column(nullable = false)
 	private Integer price;
+
+	public Item(String name, ShopCategory category, Integer price) {
+		this.name = name;
+		this.category = category;
+		this.price = price;
+	}
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
@@ -1,6 +1,9 @@
 package com.solux.piccountbe.domain.item.entity;
 
-public enum Category {
+public enum ShopCategory {
+	CAKE_SKIN,
+	CALENDER_SKIN,
+	WEB_SKIN,
 	GRAPH_SKIN;
 
 	// private final String label;

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
@@ -3,8 +3,7 @@ package com.solux.piccountbe.domain.item.entity;
 public enum ShopCategory {
 	CAKE_SKIN,
 	CALENDAR_SKIN,
-	WEB_SKIN,
-	GRAPH_SKIN;
+	WEB_SKIN
 
 	// private final String label;
 	//

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/ShopCategory.java
@@ -2,7 +2,7 @@ package com.solux.piccountbe.domain.item.entity;
 
 public enum ShopCategory {
 	CAKE_SKIN,
-	CALENDER_SKIN,
+	CALENDAR_SKIN,
 	WEB_SKIN,
 	GRAPH_SKIN;
 

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
@@ -24,7 +24,7 @@ public class Sticker {
 	@JoinColumn(name = "item_id", nullable = false)
 	private Item item;
 
-	@Column(nullable = false)
+	@Column(nullable = true)
 	private String skinImageUrl;
 
 	@Column(nullable = false)

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
@@ -26,4 +26,10 @@ public class Sticker {
 
 	@Column(nullable = false)
 	private String stickerUrl;
+
+	public Sticker(Item item, String stickerUrl) {
+		this.item = item;
+		this.stickerUrl = stickerUrl;
+	}
+
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/entity/Sticker.java
@@ -25,11 +25,15 @@ public class Sticker {
 	private Item item;
 
 	@Column(nullable = false)
-	private String stickerUrl;
+	private String skinImageUrl;
 
-	public Sticker(Item item, String stickerUrl) {
+	@Column(nullable = false)
+	private String previewImageUrl;
+
+	public Sticker(Item item, String skinImageUrl, String previewImageUrl) {
 		this.item = item;
-		this.stickerUrl = stickerUrl;
+		this.skinImageUrl = skinImageUrl;
+		this.previewImageUrl = previewImageUrl;
 	}
 
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/repository/ItemRepository.java
@@ -1,8 +1,12 @@
 package com.solux.piccountbe.domain.item.repository;
 
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.solux.piccountbe.domain.item.entity.Item;
 
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findByCategory(ShopCategory category);
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/repository/StickerRepository.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/repository/StickerRepository.java
@@ -1,8 +1,12 @@
 package com.solux.piccountbe.domain.item.repository;
 
+import com.solux.piccountbe.domain.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.solux.piccountbe.domain.item.entity.Sticker;
 
+import java.util.Optional;
+
 public interface StickerRepository  extends JpaRepository<Sticker, Long> {
+    Optional<Sticker> findByItem (Item item);
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
@@ -1,0 +1,40 @@
+package com.solux.piccountbe.domain.item.service;
+
+import com.solux.piccountbe.domain.item.dto.ItemResponseDto;
+import com.solux.piccountbe.domain.item.entity.Item;
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
+import com.solux.piccountbe.domain.item.entity.Sticker;
+import com.solux.piccountbe.domain.item.repository.ItemRepository;
+import com.solux.piccountbe.domain.item.repository.StickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+    private final StickerRepository stickerRepository;
+
+    public List<ItemResponseDto> getCalendarSkins() {
+        List<Item> items = itemRepository.findByCategory(ShopCategory.CALENDER_SKIN);
+
+        return items.stream()
+                .map(item -> {
+                    String imageUrl = stickerRepository.findByItem(item)
+                            .map(Sticker::getStickerUrl)
+                            .orElse(null);
+                    return new ItemResponseDto(
+                            item.getItemId(),
+                            item.getName(),
+                            item.getCategory(),
+                            item.getPrice(),
+                            imageUrl
+                    );
+                })
+                .toList();
+    }
+}
+

--- a/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
@@ -31,7 +31,7 @@ public class ItemService {
         return items.stream()
                 .map(item -> {
                     String imageUrl = stickerRepository.findByItem(item)
-                            .map(Sticker::getSkinImageUrl)
+                            .map(Sticker::getPreviewImageUrl)
                             .orElse(null);
                     return new ItemResponseDto(
                             item.getItemId(),
@@ -55,7 +55,7 @@ public class ItemService {
         return items.stream()
                 .map(item -> {
                     String imageUrl = stickerRepository.findByItem(item)
-                            .map(Sticker::getSkinImageUrl)
+                            .map(Sticker::getPreviewImageUrl)
                             .orElse(null);
                     return new ItemResponseDto(
                             item.getItemId(),
@@ -79,7 +79,7 @@ public class ItemService {
         return items.stream()
                 .map(item -> {
                     String imageUrl = stickerRepository.findByItem(item)
-                            .map(Sticker::getSkinImageUrl)  // 기존 stickerUrl 또는 skinImageUrl
+                            .map(Sticker::getPreviewImageUrl)  // 기존 stickerUrl 또는 skinImageUrl
                             .orElse(null);
                     return new ItemResponseDto(
                             item.getItemId(),

--- a/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
@@ -6,6 +6,8 @@ import com.solux.piccountbe.domain.item.entity.ShopCategory;
 import com.solux.piccountbe.domain.item.entity.Sticker;
 import com.solux.piccountbe.domain.item.repository.ItemRepository;
 import com.solux.piccountbe.domain.item.repository.StickerRepository;
+import com.solux.piccountbe.global.exception.CustomException;
+import com.solux.piccountbe.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,13 +20,18 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final StickerRepository stickerRepository;
 
+    // 달력 꾸미기 상품 조회
     public List<ItemResponseDto> getCalendarSkins() {
-        List<Item> items = itemRepository.findByCategory(ShopCategory.CALENDER_SKIN);
+        List<Item> items = itemRepository.findByCategory(ShopCategory.CALENDAR_SKIN);
+
+        if (items.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_ITEMS_FOUND);
+        }
 
         return items.stream()
                 .map(item -> {
                     String imageUrl = stickerRepository.findByItem(item)
-                            .map(Sticker::getStickerUrl)
+                            .map(Sticker::getSkinImageUrl)
                             .orElse(null);
                     return new ItemResponseDto(
                             item.getItemId(),
@@ -36,5 +43,31 @@ public class ItemService {
                 })
                 .toList();
     }
+
+    // 케이크 꾸미기 상품 조회
+    public List<ItemResponseDto> getCakeSkins() {
+        List<Item> items = itemRepository.findByCategory(ShopCategory.CAKE_SKIN);
+
+        if (items.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_ITEMS_FOUND);
+        }
+
+        return items.stream()
+                .map(item -> {
+                    String imageUrl = stickerRepository.findByItem(item)
+                            .map(Sticker::getSkinImageUrl)
+                            .orElse(null);
+                    return new ItemResponseDto(
+                            item.getItemId(),
+                            item.getName(),
+                            item.getCategory(),
+                            item.getPrice(),
+                            imageUrl
+                    );
+                })
+                .toList();
+    }
+
+
 }
 

--- a/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
@@ -68,6 +68,30 @@ public class ItemService {
                 .toList();
     }
 
+    // 웹 스킨 꾸미기 상품 조회
+    public List<ItemResponseDto> getWebSkins() {
+        List<Item> items = itemRepository.findByCategory(ShopCategory.WEB_SKIN);
+
+        if (items.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_ITEMS_FOUND);
+        }
+
+        return items.stream()
+                .map(item -> {
+                    String imageUrl = stickerRepository.findByItem(item)
+                            .map(Sticker::getSkinImageUrl)  // 기존 stickerUrl 또는 skinImageUrl
+                            .orElse(null);
+                    return new ItemResponseDto(
+                            item.getItemId(),
+                            item.getName(),
+                            item.getCategory(),
+                            item.getPrice(),
+                            imageUrl
+                    );
+                })
+                .toList();
+    }
+
 
 }
 

--- a/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
+++ b/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "중복된 닉네임입니다"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "일치하지 않는 패스워드입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패했습니다."),
 
     //Token
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),

--- a/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
+++ b/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패했습니다."),
 
+    // 상점
+    NO_ITEMS_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+
     //Token
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     TOKEN_EXPIRATION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),

--- a/src/main/java/com/solux/piccountbe/mock/ItemMockDataInitializer.java
+++ b/src/main/java/com/solux/piccountbe/mock/ItemMockDataInitializer.java
@@ -1,0 +1,41 @@
+package com.solux.piccountbe.mock;
+
+import com.solux.piccountbe.domain.item.entity.Item;
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
+import com.solux.piccountbe.domain.item.entity.Sticker;
+import com.solux.piccountbe.domain.item.repository.ItemRepository;
+import com.solux.piccountbe.domain.item.repository.StickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Order(1)
+public class ItemMockDataInitializer implements CommandLineRunner {
+
+    private final ItemRepository itemRepository;
+    private final StickerRepository stickerRepository;
+
+    @Override
+    public void run(String... args) {
+        if (itemRepository.count() == 0) {
+            // 달력 꾸미기 아이템
+            Item calendarSkin1 = new Item("천사 스킨", ShopCategory.CALENDER_SKIN, 2000);
+            Item calendarSkin2 = new Item("창 스킨", ShopCategory.CALENDER_SKIN, 1500);
+
+            itemRepository.saveAll(List.of(calendarSkin1, calendarSkin2));
+
+            Sticker sticker1 = new Sticker(calendarSkin1, "angel_skin.png");
+            Sticker sticker2 = new Sticker(calendarSkin2, "chang_skin.png");
+
+            stickerRepository.saveAll(List.of(sticker1, sticker2));
+
+            System.out.println("Mock ) 달력 스킨 아이템 2개 등록 완료");
+        }
+    }
+}
+

--- a/src/main/java/com/solux/piccountbe/mock/item/CakeMockDataInitializer.java
+++ b/src/main/java/com/solux/piccountbe/mock/item/CakeMockDataInitializer.java
@@ -1,0 +1,37 @@
+package com.solux.piccountbe.mock.item;
+
+import com.solux.piccountbe.domain.item.entity.Item;
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
+import com.solux.piccountbe.domain.item.entity.Sticker;
+import com.solux.piccountbe.domain.item.repository.ItemRepository;
+import com.solux.piccountbe.domain.item.repository.StickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Order(2)
+public class CakeMockDataInitializer implements CommandLineRunner {
+
+    private final ItemRepository itemRepository;
+    private final StickerRepository stickerRepository;
+
+    @Override
+    public void run(String... args) {
+        Item cakeSkin1 = new Item("핑크 케이크", ShopCategory.CAKE_SKIN, 3000);
+        Item cakeSkin2 = new Item("생크림 케이크", ShopCategory.CAKE_SKIN, 2500);
+
+        itemRepository.saveAll(List.of(cakeSkin1, cakeSkin2));
+
+        Sticker sticker1 = new Sticker(cakeSkin1, "pink_cake_skin.png", "pink_cake_preview.png");
+        Sticker sticker2 = new Sticker(cakeSkin2, "cream_cake_skin.png", "cream_cake_preview.png");
+
+        stickerRepository.saveAll(List.of(sticker1, sticker2));
+    }
+
+}
+

--- a/src/main/java/com/solux/piccountbe/mock/item/CalendarMockDataInitializer.java
+++ b/src/main/java/com/solux/piccountbe/mock/item/CalendarMockDataInitializer.java
@@ -1,4 +1,4 @@
-package com.solux.piccountbe.mock;
+package com.solux.piccountbe.mock.item;
 
 import com.solux.piccountbe.domain.item.entity.Item;
 import com.solux.piccountbe.domain.item.entity.ShopCategory;
@@ -15,7 +15,7 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 @Order(1)
-public class ItemMockDataInitializer implements CommandLineRunner {
+public class CalendarMockDataInitializer implements CommandLineRunner {
 
     private final ItemRepository itemRepository;
     private final StickerRepository stickerRepository;
@@ -24,13 +24,13 @@ public class ItemMockDataInitializer implements CommandLineRunner {
     public void run(String... args) {
         if (itemRepository.count() == 0) {
             // 달력 꾸미기 아이템
-            Item calendarSkin1 = new Item("천사 스킨", ShopCategory.CALENDER_SKIN, 2000);
-            Item calendarSkin2 = new Item("창 스킨", ShopCategory.CALENDER_SKIN, 1500);
+            Item calendarSkin1 = new Item("천사 스킨", ShopCategory.CALENDAR_SKIN, 2000);
+            Item calendarSkin2 = new Item("창 스킨", ShopCategory.CALENDAR_SKIN, 1500);
 
             itemRepository.saveAll(List.of(calendarSkin1, calendarSkin2));
 
-            Sticker sticker1 = new Sticker(calendarSkin1, "angel_skin.png");
-            Sticker sticker2 = new Sticker(calendarSkin2, "chang_skin.png");
+            Sticker sticker1 = new Sticker(calendarSkin1, "angel_skin_skin.png","angel_skin_preview.png");
+            Sticker sticker2 = new Sticker(calendarSkin2, "chang_skin_skin.png","chang_skin_preview.png");
 
             stickerRepository.saveAll(List.of(sticker1, sticker2));
 

--- a/src/main/java/com/solux/piccountbe/mock/item/WebSkinMockDataInitializer.java
+++ b/src/main/java/com/solux/piccountbe/mock/item/WebSkinMockDataInitializer.java
@@ -29,8 +29,8 @@ public class WebSkinMockDataInitializer implements CommandLineRunner {
 
         itemRepository.saveAll(List.of(webSkin1, webSkin2));
 
-        Sticker s1 = new Sticker(webSkin1, "pink_skin.png", "pink_preview.png");
-        Sticker s2 = new Sticker(webSkin2, "blue_skin.png", "blue_preview.png");
+        Sticker s1 = new Sticker(webSkin1, null, "pink_preview.png");
+        Sticker s2 = new Sticker(webSkin2, null , "blue_preview.png");
 
         stickerRepository.saveAll(List.of(s1, s2));
     }

--- a/src/main/java/com/solux/piccountbe/mock/item/WebSkinMockDataInitializer.java
+++ b/src/main/java/com/solux/piccountbe/mock/item/WebSkinMockDataInitializer.java
@@ -1,0 +1,38 @@
+package com.solux.piccountbe.mock.item;
+
+import com.solux.piccountbe.domain.item.entity.Item;
+import com.solux.piccountbe.domain.item.entity.ShopCategory;
+import com.solux.piccountbe.domain.item.entity.Sticker;
+import com.solux.piccountbe.domain.item.repository.ItemRepository;
+import com.solux.piccountbe.domain.item.repository.StickerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Order(3)
+public class WebSkinMockDataInitializer implements CommandLineRunner {
+
+    private final ItemRepository itemRepository;
+    private final StickerRepository stickerRepository;
+
+    @Override
+    public void run(String... args) {
+        if (!itemRepository.findByCategory(ShopCategory.WEB_SKIN).isEmpty()) return;
+
+        Item webSkin1 = new Item("분홍색 스킨", ShopCategory.WEB_SKIN, 1000);
+        Item webSkin2 = new Item("파란색 스킨", ShopCategory.WEB_SKIN, 1200);
+
+        itemRepository.saveAll(List.of(webSkin1, webSkin2));
+
+        Sticker s1 = new Sticker(webSkin1, "pink_skin.png", "pink_preview.png");
+        Sticker s2 = new Sticker(webSkin2, "blue_skin.png", "blue_preview.png");
+
+        stickerRepository.saveAll(List.of(s1, s2));
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
     application:
         name: piccount-BE
+    config:
+        import: optional:file:.env[.properties]
 
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### 이슈 번호
>#10

### 작업 내용
* 달력, 케이크, 웹스킨 꾸미기 상품 조회 api 구현
   * 프리뷰 이미지만 응답
* sticker 테이블에 프리뷰 이미지 속성 추가 

### 기타
