### PR TITLE
feat:#47-상점 구매 중복 방지, 챌린지 수정

### DIFF
--- a/src/main/java/com/solux/piccountbe/domain/callendar/entity/CalendarEntry.java
+++ b/src/main/java/com/solux/piccountbe/domain/callendar/entity/CalendarEntry.java
@@ -40,7 +40,7 @@ public class CalendarEntry extends Timestamped {
 	private String memo;
 
 	@Column
-	private Integer point; // 출석 포인트 추가
+	private Long point; // 출석 포인트 추가
 
 	// 무지출 챌린지는 memo 입력이 없을때
 	public boolean isNoSpendingDay() {
@@ -64,5 +64,8 @@ public class CalendarEntry extends Timestamped {
 		this.memo = memo;
 	}
 
-
+	// 포인트 저장
+	public void setPoint(long point) {
+		this.point = point;
+	}
 }

--- a/src/main/java/com/solux/piccountbe/domain/callendar/repository/CalendarEntryRepository.java
+++ b/src/main/java/com/solux/piccountbe/domain/callendar/repository/CalendarEntryRepository.java
@@ -14,11 +14,15 @@ import org.springframework.data.repository.query.Param;
 public interface CalendarEntryRepository extends JpaRepository<CalendarEntry, Long> {
     Optional<CalendarEntry> findByMemberAndEntryDate(Member member, LocalDate entryDate);
 
-    @Query("SELECT c.entryDate FROM CalendarEntry c WHERE c.member = :member AND c.entryDate IN :dates AND c.point IS NOT NULL")
-    List<LocalDate> findAttendedDatesByMemberAndDates(@Param("member") Member member, @Param("dates") List<LocalDate> dates);
-
-    @Query("SELECT COUNT(c) FROM CalendarEntry c WHERE c.member = :member AND c.memo IS NOT NULL")
-    int countNoSpendingDays(@Param("member") Member member);
-
     boolean existsByMemberAndEntryDate(Member member, LocalDate entryDate);
+
+    @Query("SELECT COUNT(c) FROM CalendarEntry c " +
+            "WHERE c.member = :member AND c.memo IS NOT NULL AND c.entryDate >= :baseDate")
+    int countNoSpendingDaysFromDate(@Param("member") Member member, @Param("baseDate") LocalDate baseDate);
+
+    // 출석 보상 수령 완료된 날짜만 필터
+    @Query("SELECT c.entryDate FROM CalendarEntry c " +
+            "WHERE c.member = :member AND c.point > 0 AND c.entryDate IN :targetDates")
+    List<LocalDate> findAttendanceRewardDates(@Param("member") Member member, @Param("targetDates") List<LocalDate> targetDates);
+
 }

--- a/src/main/java/com/solux/piccountbe/domain/callendar/service/CalendarService.java
+++ b/src/main/java/com/solux/piccountbe/domain/callendar/service/CalendarService.java
@@ -282,4 +282,15 @@ public class CalendarService {
             calendarPhotoRepository.save(newPhoto);
         }
     }
+
+    // 오늘 출석체크 포인트 저장
+    @Transactional
+    public void updateTodayPoint(Member member, long point) {
+        LocalDate today = LocalDate.now();
+
+        CalendarEntry entry = calendarEntryRepository.findByMemberAndEntryDate(member, today)
+                .orElseGet(() -> calendarEntryRepository.save(new CalendarEntry(member, today)));
+
+        entry.setPoint(point);
+    }
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/repository/PurchaseRepository.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/repository/PurchaseRepository.java
@@ -1,5 +1,6 @@
 package com.solux.piccountbe.domain.item.repository;
 
+import com.solux.piccountbe.domain.item.entity.Item;
 import com.solux.piccountbe.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
     List<Purchase> findByMember(Member member);
+
+    boolean existsByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
+++ b/src/main/java/com/solux/piccountbe/domain/item/service/ItemService.java
@@ -40,6 +40,12 @@ public class ItemService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
 
+        // 이미 샀으면 예외
+        boolean alreadyPurchased = purchaseRepository.existsByMemberAndItem(member, item);
+        if (alreadyPurchased) {
+            throw new CustomException(ErrorCode.ALREADY_PURCHASED_ITEM);
+        }
+
         // 포인트 차감 및 기록은 PointService
         pointService.deductPoints(member, item.getPrice().longValue(), Reason.ITEM_PURCHASE);
 

--- a/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
+++ b/src/main/java/com/solux/piccountbe/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
 	STICKER_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
 	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 	NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+	ALREADY_PURCHASED_ITEM(HttpStatus.CONFLICT, "이미 구매한 상품입니다."),
 
 	// 챌린지
 	CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지를 찾을 수 없습니다."),


### PR DESCRIPTION
### 이슈 번호
>#47

### 작업 내용
* 상점 중복 구매 방지
* 연속 출석 ) 매일 출석 포인트 받았는지 기준으로
* 무지출 ) 수령 후 재활성화 가능하게 수정
    * 다시 무지출 10일 이상 카운트

### 기타
